### PR TITLE
send identifier to non-command sinks as well

### DIFF
--- a/muxer_main.cpp
+++ b/muxer_main.cpp
@@ -260,7 +260,13 @@ int main(int argc, char** argv)
             printf("after acceptB %d\n", client);fflush(stdout);
             prepareAcceptedSocket(client);
             sinkList.addSink(client, OUT_BUFFER_SIZE, false);
-            // we do not send identifier to port B
+            if( src.isIdentifierPresent() )
+            {
+                printf("identifier sent\n");fflush(stdout);
+                std::vector<char> identifier;
+                src.fillIdentifier( identifier );
+                sinkList.getLastSink().putData( identifier );
+            }
         }
 
         if( FD_ISSET(src.getSocket(), &wr_set) )


### PR DESCRIPTION
It seems unlikely that this will be merged, but hopefully opening a PR will make this fix more visible to anyone using this code.

SoapyRTLTCP (and probably some other consumers) requires the rtl_tcp header to be sent, otherwise it errors out and fails to connect to the stream. This change sends the header even to non-command, sink-only clients on port B. 